### PR TITLE
Feature: enable Python 3.11 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ install_requires =
     base58
     importlib-metadata
     mnemonic
-    pyblake2
     pynacl
     python-magic
     secp256k1

--- a/src/aleph_pytezos/crypto/key.py
+++ b/src/aleph_pytezos/crypto/key.py
@@ -11,7 +11,7 @@ import secp256k1
 import nacl.signing
 
 from mnemonic import Mnemonic
-from pyblake2 import blake2b
+from hashlib import blake2b
 
 from fastecdsa.encoding.util import bytes_to_int
 from typing import Union, Optional, List
@@ -428,7 +428,9 @@ class Key():
         """Creates base58 encoded public key hash for this key.
         :returns: the public key hash for this key
         """
-        pkh = blake2b(data=self.public_point, digest_size=20).digest()
+        h = blake2b(digest_size=20)
+        h.update(self.public_point)
+        pkh = h.digest()
         prefix = {b'ed': b'tz1', b'sp': b'tz2', b'p2': b'tz3'}[self.curve]
         return base58_encode(pkh, prefix).decode()
 
@@ -497,7 +499,9 @@ class Key():
 
         # Ed25519
         if self.curve == b"ed":
-            digest = blake2b(data=encoded_message, digest_size=32).digest()
+            h = blake2b(digest_size=32)
+            h.update(encoded_message)
+            digest = h.digest()
             nacl.signing.VerifyKey(self.public_point).verify(digest, decoded_signature)
         # Secp256k1
         elif self.curve == b"sp":


### PR DESCRIPTION
Problem: building the project under Python 3.11 fails because of the dependency to pyblake2.

Solution: use the hashlib implementation of blake2b. It is based on pyblake2, is compatible with Python 3.11 and is packaged with Python.