### PR TITLE
Replace pysodium with libnacl

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     coincurve >= 20.0.0
     typing_extensions
     fastecdsa
-    pysodium
+    libnacl
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
The library `pysodium` is used as "a very simple wrapper around libsodium masquerading as nacl".

`libnacl` is another wrapper around the nacl library developed and maintained by the Salt
project and with extensive documentation on https://libnacl.readthedocs.io and has been
update to use the `pyproject.toml` format. The status of this library is marked as `5 - Production/Stable` on PyPI.

The `pysodium` library has a bare bone repository with no documentation available and still uses the old 'setup.py' format. The status of this library is marked as `4 - Beta` on PyPI.